### PR TITLE
Fix Melpa URL

### DIFF
--- a/init.el
+++ b/init.el
@@ -1,6 +1,6 @@
 (require 'package)
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "http://melpa.org/packages/") t)
 
 ;;; from purcell/emacs.d
 (defun require-package (package &optional min-version no-refresh)


### PR DESCRIPTION
On startup, emacs would fail with `error: Package ‘evil-’ is unavailable`.
Had to set correct URL, looked it up at https://www.emacswiki.org/emacs/Evil#toc1